### PR TITLE
Avoid suggesting that the library is "downloadable" from Clojars

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Thats what _pretty_ is for.  It adds support for pretty output where it counts:
 
 pretty is available under the terms of the Apache Software License 2.0.
 
-pretty is downloadable from the [Clojars Repository](https://clojars.org/io.aviso/pretty).
+## Dependency/Installation
+
+pretty dependency information can be found on its [Clojars Repository](https://clojars.org/io.aviso/pretty)
+page.
 
 ## io.aviso.ansi
 


### PR DESCRIPTION
Nobody manages dependencies manually if there
are released artefacts. The current wording
may mislead beginners to think they need to download
`.jar` and use it that way.
