### PR TITLE
Add middleware descriptor to `pretty-middleware`

### DIFF
--- a/src/io/aviso/nrepl.clj
+++ b/src/io/aviso/nrepl.clj
@@ -1,9 +1,16 @@
 (ns io.aviso.nrepl
   "nREPL middleware to enable pretty exception reportinging in the REPL."
-  (:use [io.aviso.repl]))
+  (:use [io.aviso.repl])
+  (:require [clojure.tools.nrepl.middleware :refer [set-descriptor!]]))
 
 (defn pretty-middleware
   "nREPL middleware that simply ensures that pretty exception reporting is installed."
   [handler]
   (install-pretty-exceptions)
   handler)
+
+(set-descriptor!
+  #'pretty-middleware
+  {:expects #{}
+   :requires #{}
+   :handles #{}})


### PR DESCRIPTION
This commit resolves issue #28. To review, at the moment opening a REPL
logs the following warning: "[WARNING] No nREPL middleware descriptor in
metadata of #'io.aviso.nrepl/pretty-middleware, see
clojure.tools.middleware/set-descriptor!"

In point of fact, they want you to look at
`clojure.tools.nrepl.middleware/set-descriptor!`

At any rate, this commit sets descriptor metadata on
`io.aviso.nrepl/pretty-middleware` so the error stops being thrown.