### PR TITLE
[typo] fixing a typo in the fonts map

### DIFF
--- a/src/io/aviso/exception.clj
+++ b/src/io/aviso/exception.clj
@@ -201,7 +201,7 @@
    :function-name  bold-yellow-font
    :clojure-frame  yellow-font
    :java-frame     white-font
-   :omiitted-frame white-font})
+   :omitted-frame white-font})
 
 (defn- preformat-stack-frame
   [frame]


### PR DESCRIPTION
This is a pretty minor fix, but the *fonts* map in `io.aviso.exceptions` has a typo in the `:omitted-frame` key. One might not even care about this but it turns out it's spelled correctly everywhere else, so we might as well fix it.