### PR TITLE
Prefer map over record for exception dispatch

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.aviso/pretty "0.1.24"
+(defproject io.aviso/pretty "0.1.25"
   :description "Clojure library to help print things, prettily"
   :url "https://github.com/AvisoNovate/pretty"
   :license {:name "Apache Sofware License 2.0"

--- a/src/io/aviso/exception.clj
+++ b/src/io/aviso/exception.clj
@@ -479,6 +479,8 @@
   [_]
   (pp/simple-dispatch nil))
 
+(prefer-method exception-dispatch clojure.lang.IPersistentMap clojure.lang.IRecord)
+
 (defn- format-property-value
   [value]
   (pp/write value :stream nil :length (or *print-length* 10) :dispatch exception-dispatch))


### PR DESCRIPTION
Hi there,

We've been using pretty in some of our apps through [timbre](https://github.com/ptaoussanis/timbre) and we've noticed that sometimes doesn't know how to pretty print records as they would match the multimethod `exception-dispatch` on both `clojure.lang.IPersistentMap` and `clojure.lang.IRecord`. These record are usually components part of a system map.

We've fixed it by adding a `prefer-method` for `clojure.lang.IPersistentMap`. As this looks like a more general issue, we thought that it might be good idea to add the fix to pretty. 

Interested in hearing your thoughts on it.

The following is the output of one of the exceptions we've seen:
```
                     io.aviso.exception/format-exception                     exception.clj:  468
        io.aviso.exception/format-exception/invokeStatic                     exception.clj:  471
                     io.aviso.exception/format-exception                     exception.clj:  468
        io.aviso.exception/format-exception/invokeStatic                     exception.clj:  473
                                                     ...
                             io.aviso.writer/into-string                        writer.clj:   55
                io.aviso.writer/into-string/invokeStatic                        writer.clj:   61
                                      clojure.core/apply                          core.clj:  641
                         clojure.core/apply/invokeStatic                          core.clj:  648
                                                     ...
                      io.aviso.exception/write-exception                     exception.clj:  375
         io.aviso.exception/write-exception/invokeStatic                     exception.clj:  464
io.aviso.exception/write-exception/write-exception-stack                     exception.clj:  457
                io.aviso.exception/format-property-value                     exception.clj:  369
   io.aviso.exception/format-property-value/invokeStatic                     exception.clj:  371
                                                     ...
                                    clojure.pprint/write                   pprint_base.clj:  197
                       clojure.pprint/write/invokeStatic                   pprint_base.clj:  233
                                 clojure.pprint/write/fn                   pprint_base.clj:  233
                   clojure.pprint/write-out/invokeStatic                   pprint_base.clj:  194
                                                     ...
     java.lang.IllegalArgumentException: Multiple methods in multimethod 'exception-dispatch' match dispatch value: class SomeRecord -> interface clojure.lang.IPersistentMap and interface clojure.lang.IRecord, and neither is preferred
```