### PR TITLE
Switch to using macros instead of eval

### DIFF
--- a/src/io/aviso/ansi.clj
+++ b/src/io/aviso/ansi.clj
@@ -19,23 +19,21 @@
   "Resets the font, clearing bold, italic, color, and background color."
   (str csi sgr))
 
-(defn ^:private def-sgr-const
+(defmacro ^:private def-sgr-const
   "Utility for defining a font-modifying constant."
   [symbol-name color-name & codes]
-  (eval
-    `(def ^:const ~(symbol symbol-name)
-       ~(format "Constant for ANSI code to enable %s text." color-name)
-       ~(str csi (str/join ";" codes) sgr))))
+  `(def ~(vary-meta (symbol symbol-name) assoc :const true)
+     ~(format "Constant for ANSI code to enable %s text." color-name)
+     (str csi ~(str/join ";" codes) sgr)))
 
-(defn ^:private def-sgr-fn
+(defmacro ^:private def-sgr-fn
   "Utility for creating a function that enables some combination of SGR codes around some text, but resets
   the font after the text."
   [fn-name color-name & codes]
-  (eval
-    `(defn ~(symbol fn-name)
-       ~(format "Wraps the provided text with ANSI codes to render as %s text." color-name)
-       [~'text]
-       (str ~(str csi (str/join ";" codes) sgr) ~'text ~reset-font))))
+  `(defn ~(symbol fn-name)
+     ~(format "Wraps the provided text with ANSI codes to render as %s text." color-name)
+     [text#]
+     (str csi ~(str/join ";" codes) sgr text# reset-font)))
 
 ;;; Define functions and constants for each color. The functions accept a string
 ;;; and wrap it with the ANSI codes to set up a rendition before the text,
@@ -54,26 +52,38 @@
 ;;;   - bold-C-font; enable bold text in that color (e.g., "bold-green-font")
 ;;;   - bold-C-bg-font; enable background in that bold color (e.g., "bold-green-bg-font")
 
-(doall
-  (map-indexed (fn [index color-name]
-                 (def-sgr-fn color-name color-name (+ 30 index))
-                 (def-sgr-fn (str color-name "-bg") (str color-name " background") (+ 40 index))
-                 (def-sgr-fn (str "bold-" color-name) (str "bold " color-name) 1 (+ 30 index))
-                 (def-sgr-fn (str "bold-" color-name "-bg") (str "bold " color-name " background") 1 (+ 40 index))
-                 (def-sgr-const (str color-name "-font") color-name (+ 30 index))
-                 (def-sgr-const (str color-name "-bg-font") (str color-name " background") (+ 40 index))
-                 (def-sgr-const (str "bold-" color-name "-font") (str "bold " color-name) 1 (+ 30 index))
-                 (def-sgr-const (str "bold-" color-name "-bg-font") (str "bold " color-name " background") 1 (+ 40 index)))
-               ["black" "red" "green" "yellow" "blue" "magenta" "cyan" "white"]))
+(defmacro define-colors
+  []
+  `(do
+     ~@(map-indexed
+         (fn [index color-name]
+           `(do
+              (def-sgr-fn ~color-name ~color-name ~(+ 30 index))
+              (def-sgr-fn ~(str color-name "-bg") ~(str color-name " background") ~(+ 40 index))
+              (def-sgr-fn ~(str "bold-" color-name) ~(str "bold " color-name) 1 ~(+ 30 index))
+              (def-sgr-fn ~(str "bold-" color-name "-bg") ~(str "bold " color-name " background") 1 ~(+ 40 index))
+              (def-sgr-const ~(str color-name "-font") ~color-name ~(+ 30 index))
+              (def-sgr-const ~(str color-name "-bg-font") ~(str color-name " background") ~(+ 40 index))
+              (def-sgr-const ~(str "bold-" color-name "-font") ~(str "bold " color-name) 1 ~(+ 30 index))
+              (def-sgr-const ~(str "bold-" color-name "-bg-font") ~(str "bold " color-name " background") 1 ~(+ 40 index))))
+         ["black" "red" "green" "yellow" "blue" "magenta" "cyan" "white"])))
+
+(define-colors)
 
 ;; ANSI defines quite a few more, but we're limiting to those that display properly in the
 ;; Cursive REPL.
 
-(doseq [[font-name code] [['bold 1]
-                          ['italic 3]
-                          ['inverse 7]]]
-  (def-sgr-fn font-name font-name code)
-  (def-sgr-const (str font-name "-font") font-name code))
+(defmacro define-fonts
+  []
+  `(do
+     ~@(for [[font-name code] [['bold 1]
+                               ['italic 3]
+                               ['inverse 7]]]
+         `(do
+            (def-sgr-fn ~font-name ~font-name ~code)
+            (def-sgr-const ~(str font-name "-font") ~font-name ~code)))))
+
+(define-fonts)
 
 (def ^:const ^:private ansi-pattern (Pattern/compile "\\e\\[.*?m"))
 


### PR DESCRIPTION
Eval doesn't play nicely with AOT - new instances of functions/constants are created every time the namespace is loaded. This means when doing incremental AOT, io.aviso.pretty generates classes whenever it's `require`d, even if it is itself AOTed already.

This switches from `eval` to `defmacro` for the same effect, but better integration with core clojure.

Testing done: `lein test`.
