### PR TITLE
Add possibility to turn off default set of fonts used for exception formatting.

### DIFF
--- a/src/io/aviso/exception.clj
+++ b/src/io/aviso/exception.clj
@@ -12,8 +12,8 @@
            [clojure.lang Compiler ExceptionInfo]
            [java.util.regex Pattern]))
 
-(def ^:dynamic *fonts*
-  "ANSI fonts for different elements in the formatted exception report."
+(def default-fonts
+  "A default set of fonts for different elements in the formatted exception report."
   {:exception     bold-red-font
    :reset         reset-font
    :message       italic-font
@@ -23,6 +23,11 @@
    :clojure-frame yellow-font
    :java-frame    white-font
    :omitted-frame white-font})
+
+(def ^:dynamic *fonts*
+  "Current set of fonts used in exception formatting"
+  (when-not (System/getenv "DISABLE_DEFAULT_PRETTY_FONTS")
+    default-fonts))
 
 (def ^{:dynamic true
        :added   "0.1.15"}
@@ -605,7 +610,9 @@
   to configure pretty-printing; however, if `*print-length*` is left as its default (nil), the print length will be set to 10.
   This is to ensure that infinite lists do not cause endless output or other exceptions.
 
-  The `*fonts*` var contains ANSI definitions for how fonts are displayed; bind it to nil to remove ANSI formatting entirely."
+  The `*fonts*` var contains ANSI definitions for how fonts are displayed; bind it to nil to remove ANSI formatting entirely.
+  It can be also initialized to nil instead of the default set of fonts by setting environment variable DISABLE_DEFAULT_PRETTY_FONTS
+  to any value."
   ([exception]
    (write-exception *out* exception))
   ([writer exception]


### PR DESCRIPTION
In some scenarios it would be useful to turn off default ANSI fonts globally
in environments where it might cause issues (e.g. polluting logs fed to
other systems for storage and not read by human directly but through a
different interface where ANSI characters are rendered incorrectly).