### PR TITLE
Fix ns import declaration

### DIFF
--- a/src/io/aviso/logging.clj
+++ b/src/io/aviso/logging.clj
@@ -6,7 +6,7 @@
   (:require [clojure.tools.logging :as l]
             [io.aviso.exception :as e]
             [io.aviso.writer :as writer])
-  (:import [java.lang.Thread$UncaughtExceptionHandler]))
+  (:import [java.lang Thread$UncaughtExceptionHandler]))
 
 (defn install-pretty-logging
   "Modifies clojure.tools.logging to use pretty exception logging."


### PR DESCRIPTION
Using clojure-1.10-rc1, I'm getting the following error when requiring `io.aviso.logging`:
```
Exception in thread "main" Syntax error macroexpanding clojure.core/ns at (io/aviso/logging.clj:1:1).
	at clojure.lang.Compiler.checkSpecs(Compiler.java:6982)
	at clojure.lang.Compiler.macroexpand1(Compiler.java:6998)
	at clojure.lang.Compiler.macroexpand(Compiler.java:7078)
	at clojure.lang.Compiler.eval(Compiler.java:7156)
	at clojure.lang.Compiler.load(Compiler.java:7631)
	at clojure.lang.RT.loadResourceScript(RT.java:379)
	at clojure.lang.RT.loadResourceScript(RT.java:370)
	at clojure.lang.RT.load(RT.java:461)
	at clojure.lang.RT.load(RT.java:426)
	at clojure.core$load$fn__6735.invoke(core.clj:6098)
	at clojure.core$load.invokeStatic(core.clj:6097)
	at clojure.core$load.doInvoke(core.clj:6081)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at clojure.core$load_one.invokeStatic(core.clj:5900)
	at clojure.core$load_one.invoke(core.clj:5895)
	at clojure.core$load_lib$fn__6680.invoke(core.clj:5940)
	at clojure.core$load_lib.invokeStatic(core.clj:5939)
	at clojure.core$load_lib.doInvoke(core.clj:5920)
	at clojure.lang.RestFn.applyTo(RestFn.java:142)
	at clojure.core$apply.invokeStatic(core.clj:659)
	at clojure.core$load_libs.invokeStatic(core.clj:5977)
	at clojure.core$load_libs.doInvoke(core.clj:5961)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.core$apply.invokeStatic(core.clj:659)
	at clojure.core$require.invokeStatic(core.clj:5999)
	at clojure.core$require.doInvoke(core.clj:5999)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at main$eval138$loading__6621__auto____139.invoke(NO_SOURCE_FILE:1)
	at main$eval138.invokeStatic(NO_SOURCE_FILE:1)
	at main$eval138.invoke(NO_SOURCE_FILE:1)
	at clojure.lang.Compiler.eval(Compiler.java:7172)
	at clojure.lang.Compiler.eval(Compiler.java:7161)
	at clojure.lang.Compiler.eval(Compiler.java:7135)
	at clojure.core$eval.invokeStatic(core.clj:3206)
	at clojure.main$eval_opt.invokeStatic(main.clj:360)
	at clojure.main$eval_opt.invoke(main.clj:354)
	at clojure.main$initialize.invokeStatic(main.clj:380)
	at clojure.main$null_opt.invokeStatic(main.clj:414)
	at clojure.main$null_opt.invoke(main.clj:411)
	at clojure.main$main.invokeStatic(main.clj:493)
	at clojure.main$main.doInvoke(main.clj:456)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:705)
	at clojure.main.main(main.java:37)
Caused by: clojure.lang.ExceptionInfo: Call to clojure.core/ns did not conform to spec. {:clojure.spec.alpha/problems ({:path [:ns-clauses :refer-clojure :clause], :pred #{:refer-clojure}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-refer-clojure :clojure.core.specs.alpha/ns-refer-clojure], :in [4 0]} {:path [:ns-clauses :require :clause], :pred #{:require}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-require :clojure.core.specs.alpha/ns-require], :in [4 0]} {:path [:ns-clauses :import :classes :class], :pred clojure.core/simple-symbol?, :val [java.lang.Thread$UncaughtExceptionHandler], :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-import :clojure.core.specs.alpha/ns-import :clojure.core.specs.alpha/import-list], :in [4 1]} {:path [:ns-clauses :import :classes :package-list :classes], :reason "Insufficient input", :pred clojure.core/simple-symbol?, :val (), :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-import :clojure.core.specs.alpha/ns-import :clojure.core.specs.alpha/import-list :clojure.core.specs.alpha/package-list :clojure.core.specs.alpha/package-list], :in [4 1]} {:path [:ns-clauses :use :clause], :pred #{:use}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-use :clojure.core.specs.alpha/ns-use], :in [4 0]} {:path [:ns-clauses :refer :clause], :pred #{:refer}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-refer :clojure.core.specs.alpha/ns-refer], :in [4 0]} {:path [:ns-clauses :load :clause], :pred #{:load}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-load :clojure.core.specs.alpha/ns-load], :in [4 0]} {:path [:ns-clauses :gen-class :clause], :pred #{:gen-class}, :val :import, :via [:clojure.core.specs.alpha/ns-form :clojure.core.specs.alpha/ns-gen-class :clojure.core.specs.alpha/ns-gen-class], :in [4 0]}), :clojure.spec.alpha/spec #object[clojure.spec.alpha$regex_spec_impl$reify__2509 0x4b41dd5c "clojure.spec.alpha$regex_spec_impl$reify__2509@4b41dd5c"], :clojure.spec.alpha/value (io.aviso.logging "Provides functions that hook into clojure.tools.logging to make use of Pretty to format exceptions.\n\n  You must [add clojure.tools.logging as an explicit dependency](https://github.com/clojure/tools.logging) of your project." {:added "0.1.15"} (:require [clojure.tools.logging :as l] [io.aviso.exception :as e] [io.aviso.writer :as writer]) (:import [java.lang.Thread$UncaughtExceptionHandler])), :clojure.spec.alpha/args (io.aviso.logging "Provides functions that hook into clojure.tools.logging to make use of Pretty to format exceptions.\n\n  You must [add clojure.tools.logging as an explicit dependency](https://github.com/clojure/tools.logging) of your project." {:added "0.1.15"} (:require [clojure.tools.logging :as l] [io.aviso.exception :as e] [io.aviso.writer :as writer]) (:import [java.lang.Thread$UncaughtExceptionHandler]))}
	at clojure.spec.alpha$macroexpand_check.invokeStatic(alpha.clj:705)
	at clojure.spec.alpha$macroexpand_check.invoke(alpha.clj:697)
	at clojure.lang.AFn.applyToHelper(AFn.java:156)
	at clojure.lang.AFn.applyTo(AFn.java:144)
	at clojure.lang.Var.applyTo(Var.java:705)
	at clojure.lang.Compiler.checkSpecs(Compiler.java:6980)
	... 43 more
```

The problems seems to be that the `:import` declaration in `io.aviso.logging` doesn't conform to the specs in `clojure.core.specs.alpha`. This PR fixes this.