### PR TITLE
Use explicitly configured middleware

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,13 @@
 ## 0.1.37 - UNRELEASED
 
-*Incompatible Change*: Remove the `io.aviso.writer` namespace and change many functions
-to simply write to `*out*` rather than take a writer parameter.
+*Incompatible Changes*:
+
+* Removed the `io.aviso.writer` namespace and changed many functions
+  to simply write to `*out*` rather than take a writer parameter.
+
+* It is now necessary to setup explicit :middleware in your `project.clj`, as
+  Leiningen is phasing out implicit middleware.
+  See the manual for more details.
 
 ## 0.1.36 - 22 Dec 2018
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@ import sys
 import os
 import shlex
 
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -55,8 +56,17 @@ author = u'Howard M. Lewis Ship and others'
 # built documents.
 #
 
+def read_project_version():
+    f = open("../project.clj")
+    line = f.readline()
+    terms = line.split('"')
+    f.close()
+
+    return terms[1]
+
+
 # The full version, including alpha/beta/rc tags.
-release = u'0.1.36'
+release = read_project_version()
 
 # The short X.Y version.
 version = release

--- a/docs/lein-plugin.rst
+++ b/docs/lein-plugin.rst
@@ -11,13 +11,17 @@ of your :file:`project.clj`.
 .. code-block:: clojure
 
   (defproject ...
-   :plugins [[io.aviso/pretty "1.0.0"]]
+   :plugins [[io.aviso/pretty "X.Y.Z"]]
+   :middleware [io.aviso.lein-pretty/inject]
    :dependencies [...
-                  [io.aviso/pretty "1.0.0"]]
+                  [io.aviso/pretty "X.Y.Z"]]
    ...)
 
-
 Adjust the version number for the current version, "|release|".
+
+.. tip::
+
+   Often, you only add ``io.aviso/pretty`` to your :dev profile dependencies.
 
 This adds middleware to enable pretty exception reporting when running a REPL, tests,
 or anything else that starts code in the project.
@@ -27,8 +31,9 @@ Another option is to add the following to your :file:`~/.lein/profiles.clj`:
 .. code-block:: clojure
 
    :pretty {
-     :plugins [[io.aviso/pretty "1.0.0"]]
-     :dependencies [[io.aviso/pretty "1.0.0"]]
+     :plugins [[io.aviso/pretty "X.Y.Z"]]
+     :dependencies [[io.aviso/pretty "X.Y.Z"]]
+     :middleware [io.aviso.lein-pretty/inject]
    }
 
 This creates an opt-in profile that adds and enables pretty exception reporting.

--- a/project.clj
+++ b/project.clj
@@ -3,14 +3,15 @@
   :url "https://github.com/AvisoNovate/pretty"
   :license {:name "Apache Sofware License 2.0"
             :url  "http://www.apache.org/licenses/LICENSE-2.0.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/tools.logging "0.3.1" :optional true]]
+  :dependencies [[org.clojure/clojure "1.10.0"]
+                 [org.clojure/tools.logging "0.4.1" :optional true]]
   :plugins [[lein-codox "0.10.4"]]
   :profiles {:1.9  {:dependencies [[org.clojure/clojure "1.9.0"]]}
+             :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :dev  {:dependencies [[criterium "0.4.4"]
                                    [com.stuartsierra/component "0.3.2"]
                                    [com.walmartlabs/test-reporting "0.1.0"]]}
-             :lein {:dependencies [[leiningen "2.8.1"]]}}
+             :lein {:dependencies [[leiningen "2.8.2"]]}}
   ;; Part of release is currently manual; copy target/docs to the AvisoNovate/docs/pretty folder
   :aliases {"release" ["do"
                        "clean,"

--- a/src/io/aviso/exception.clj
+++ b/src/io/aviso/exception.clj
@@ -7,9 +7,10 @@
             [io.aviso
              [ansi :as ansi]
              [columns :as c]])
-  (:import [java.lang StringBuilder StackTraceElement]
-           [clojure.lang Compiler ExceptionInfo Named]
-           [java.util.regex Pattern]))
+  (:import
+    (java.lang StringBuilder StackTraceElement)
+    (clojure.lang Compiler ExceptionInfo Named)
+    (java.util.regex Pattern)))
 
 (def default-fonts
   "A default set of fonts for different elements in the formatted exception report."

--- a/src/io/aviso/lein_pretty.clj
+++ b/src/io/aviso/lein_pretty.clj
@@ -1,22 +1,18 @@
-(ns pretty.plugin
+(ns io.aviso.lein-pretty
   "A plugin for Leiningen that automatically enables pretty printing."
   {:added "0.1.19"}
-  (:require [io.aviso.repl :as repl]
-            [leiningen.core.main :as main]))
-
-(defn hooks
-  "Enables pretty printing of exceptions within Leiningen. This is evaluated in the Leinigen classpath, not the project's
-  (if any)."
-  []
-  (repl/install-pretty-exceptions))
-
+  (:require
+    [leiningen.core.main :as main]))
 
 ;; Ugly! But necessary since middleware gets invoked more than once for some unknown reason.
 (def ^:private print-warning
   (delay (main/warn "Unable to enable pretty exception reporting, as io.aviso/pretty is not a project dependency.")))
 
-(defn middleware
-  "Automatically adds the :injections that enable Pretty."
+(defn inject
+  "Adds the :injections that enable Pretty inside the project's process, by executing
+  `(io.aviso.repl/install-pretty-exceptions)`.
+
+  This is enabled by adding `io.aviso.lein-pretty/inject` to the :middleware of the project.clj."
   [project]
   (if (contains? (->> project
                       :dependencies
@@ -33,5 +29,7 @@
                     (println "Error loading io.aviso/pretty support:"
                              (or (.getMessage t#)
                                  (type t#))))))
-    (do @print-warning project)))
+    (do
+      @print-warning
+      project)))
 


### PR DESCRIPTION
Future versions of Leiningen will not support implicit middleware, or will produce warnings.

Fixes #69 
Fixes #68 

This also removes the hook that attempted to install Pretty into the parent Leiningen process ... that never worked, as Leiningen captures and reports exceptions thrown by plugins in its own code that pretty doesn't override.