### PR TITLE
Flatten ns require forms.

### DIFF
--- a/src/io/aviso/binary.clj
+++ b/src/io/aviso/binary.clj
@@ -1,8 +1,7 @@
 (ns io.aviso.binary
   "Utilities for formatting binary data (byte arrays) or binary deltas."
-  (:require [io.aviso
-             [ansi :as ansi]
-             [columns :as c]]))
+  (:require [io.aviso.ansi :as ansi]
+            [io.aviso.columns :as c]))
 
 (defprotocol BinaryData
   "Allows various data sources to be treated as a byte-array data type that

--- a/src/io/aviso/columns.clj
+++ b/src/io/aviso/columns.clj
@@ -4,8 +4,7 @@
   When a value is provided in a column, it may be associated with an explicit width which is helpful
   when the value contains non-printing characters (such as those defined in the `io.aviso.ansi` namespace)."
   (:require [clojure.string :as str]
-            [io.aviso
-             [ansi :as ansi]]))
+            [io.aviso.ansi :as ansi]))
 
 (defn ^:private indent
   "Indents sufficient to pad the column value to the column width."

--- a/src/io/aviso/exception.clj
+++ b/src/io/aviso/exception.clj
@@ -1,12 +1,10 @@
 (ns io.aviso.exception
   "Format and present exceptions in a pretty (structured, formatted) way."
-  (:require [clojure
-             [pprint :as pp]
-             [set :as set]
-             [string :as str]]
-            [io.aviso
-             [ansi :as ansi]
-             [columns :as c]])
+  (:require [clojure.pprint :as pp]
+            [clojure.set :as set]
+            [clojure.string :as str]
+            [io.aviso.ansi :as ansi]
+            [io.aviso.columns :as c])
   (:import
     (java.lang StringBuilder StackTraceElement)
     (clojure.lang Compiler ExceptionInfo Named)


### PR DESCRIPTION
Some tools, such as babashka, struggle with nested ns forms such as

```clj
(ns io.aviso.columns
  (:require [clojure.string :as str]
            [io.aviso
             [ansi :as ansi]]))
```

while flattening these aren't problematic

```clj
(ns io.aviso.columns
  (:require [clojure.string :as str]
            [io.aviso.ansi :as ansi]]))
```

Ideally babashka can be taught to handle these, but it's probably not a terrible thing to use the more common flattened require forms here.
