### PR TITLE
Fix an NPE when the ex-info map has a nil key

### DIFF
--- a/src/io/aviso/exception.clj
+++ b/src/io/aviso/exception.clj
@@ -515,6 +515,11 @@
         x-name))
     x))
 
+(defn ^:private replace-nil [x]
+  (if (nil? x)
+    "nil"
+    x))
+
 (defn write-exception*
   "Contains the main logic for [[write-exception]], which simply expands
   the exception (via [[analyze-exception]]) before invoking this function.
@@ -537,7 +542,7 @@
                                    (exception-formatter (str exception-font class-name reset-font)
                                                         (str message-font message reset-font))
                                    (when show-properties?
-                                     (let [properties         (update-keys (:properties e) qualified-name)
+                                     (let [properties         (update-keys (:properties e) (comp replace-nil qualified-name))
                                            prop-keys-sorted   (cond-> (keys properties)
                                                                       (not (sorted? (:properties e)))
                                                                       (sort))

--- a/test/io/aviso/exception_test.clj
+++ b/test/io/aviso/exception_test.clj
@@ -576,3 +576,8 @@
 
       (reporting {comp-exception (str/split-lines comp-exception)}
                  (is (re-find #"component: #<Component io.aviso.exception_test.MyComponent>" comp-exception))))))
+
+(deftest write-exceptions-with-nil-data
+  (testing "Does not fail with a nil ex-info map key"
+    (is (re-find #"nil.*nil"
+                 (format-exception (ex-info "Error" {nil nil}))))))


### PR DESCRIPTION
This commit fixes a NullPointerException when the ex-info data map
contains a nil key. It replaces the nil with a string nil so it will
still show up in the output, but doesn't break the string replace
functions.