### PR TITLE
Avoid warns in clojure 1.11

### DIFF
--- a/src/io/aviso/exception.clj
+++ b/src/io/aviso/exception.clj
@@ -1,5 +1,6 @@
 (ns io.aviso.exception
   "Format and present exceptions in a pretty (structured, formatted) way."
+  (:refer-clojure :exclude [update-keys])
   (:require [clojure.pprint :as pp]
             [clojure.set :as set]
             [clojure.string :as str]


### PR DESCRIPTION
Clojure 1.11 introduced a update-keys

Without this change, we will see this warn line every time we load the library
> WARNING: update-keys already refers to: #'clojure.core/update-keys in namespace: io.aviso.exception, being replaced by: #'io.aviso.exception/update-keys