### PR TITLE
Add io.aviso.ansi/compose

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.5.0
+
+      - name: Setup Java
+        uses: actions/setup-java@v3.11.0
+        with:
+          java-version: '11'
+          distribution: 'corretto'
+
+      - name: Install clojure tools
+        uses: DeLaGuardo/setup-clojure@10.2
+        with:
+          cli: 1.11.1.1257
+
+      - name: Cache clojure dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          # List all files containing dependencies:
+          key: cljdeps-${{ hashFiles('deps.edn') }}
+
+      - name: Run JVM tests
+        run: clojure -X:dev:test
+
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 [![Clojars](https://img.shields.io/clojars/v/io.aviso/pretty.svg)](http://clojars.org/io.aviso/pretty)
 
-[![CircleCI](https://circleci.com/gh/AvisoNovate/pretty.svg?style=svg)](https://circleci.com/gh/AvisoNovate/pretty)
-
 [Full Documentation](http://ioavisopretty.readthedocs.org/en/latest/)
 
 [API](http://avisonovate.github.io/docs/pretty/)

--- a/build.clj
+++ b/build.clj
@@ -22,14 +22,13 @@
 (defn deploy
   [_params]
   (clean nil)
-  (jar nil)
-  (b/deploy-jar jar-params))
+  (b/deploy-jar (jar nil)))
 
 (defn codox
   [_params]
-  (b/codox {:project-name lib
-            :version version
-            :aliases [:dev]}))
+  (b/generate-codox {:project-name lib
+                     :version version
+                     :aliases [:dev]}))
 
 (def publish-dir "../aviso-docs/pretty")
 

--- a/deps.edn
+++ b/deps.edn
@@ -8,8 +8,8 @@
                 criterium/criterium {:mvn/version "0.4.6"}
                 com.stuartsierra/component {:mvn/version "1.1.0"}
                 com.walmartlabs/test-reporting {:mvn/version "1.2"}
-                org.clojure/core.async {:mvn/version "1.5.648"}
-                leiningen/leiningen {:mvn/version "2.9.8"}}}
+                org.clojure/core.async {:mvn/version "1.6.673"}
+                leiningen/leiningen {:mvn/version "2.10.0"}}}
 
   ;; clj -X:dev:test
   :test
@@ -20,7 +20,7 @@
   ;; clj -T:build <command>
   :build
   {:deps {io.github.hlship/build-tools
-          {:git/tag "v0.5" :git/sha "ca4876"}}
+          {:git/tag "0.8" :git/sha "0a0c26"}}
    :ns-default build}}
 
  :main


### PR DESCRIPTION
The new `compose` function makes it far easier to put together strings with more complex font characteristics.

In addition, the `bold-<color>` functions, and `bold-<color>-font` constants were deprecated and replaced with a `bright-` prefix.